### PR TITLE
Fixed undefined MIX_INIT_MODPLUG

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -171,11 +171,11 @@ bool Game::Load(char * cmdline){
 		return false;
 	}
 	int mixinitted;
-	if((mixinitted = Mix_Init(MIX_INIT_MP3 | MIX_INIT_MOD | MIX_INIT_MODPLUG)) == -1){
+	if((mixinitted = Mix_Init(MIX_INIT_MP3 | MIX_INIT_MOD )) == -1){
 		printf("Could not initialize SDL_mixer %s\n", Mix_GetError());
 		return false;
 	}
-	if(!(mixinitted & MIX_INIT_MOD) && !(mixinitted & MIX_INIT_MODPLUG)){
+	if(!(mixinitted & MIX_INIT_MOD) && !(mixinitted & MIX_INIT_MOD)){
 		printf("Could not initialize MOD support %s\n", Mix_GetError());
 	}
 	if(!(mixinitted & MIX_INIT_MP3)){

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -175,7 +175,7 @@ bool Game::Load(char * cmdline){
 		printf("Could not initialize SDL_mixer %s\n", Mix_GetError());
 		return false;
 	}
-	if(!(mixinitted & MIX_INIT_MOD) && !(mixinitted & MIX_INIT_MOD)){
+	if(!(mixinitted & MIX_INIT_MOD)){
 		printf("Could not initialize MOD support %s\n", Mix_GetError());
 	}
 	if(!(mixinitted & MIX_INIT_MP3)){


### PR DESCRIPTION
In SDL mixer 2.0.2 this flag was removed. This fixes the build.
